### PR TITLE
Add docstring for test_user endpoint

### DIFF
--- a/app/api/v1/users/login.py
+++ b/app/api/v1/users/login.py
@@ -6,4 +6,13 @@ router = APIRouter(tags=["Users"])
 @router.post("/test_user")
 async def test_user(login: str,
                     password: int):
+    """Log the user test endpoint invocation.
+
+    Args:
+        login (str): Unique identifier of the user initiating the request.
+        password (int): Numeric password provided for the authentication attempt.
+
+    Returns:
+        None: This endpoint only records the request for auditing purposes.
+    """
     logging.info(f"Попытка добавить нового юзера {login} {password}")


### PR DESCRIPTION
## Summary
- add a Google-style docstring to the `test_user` endpoint describing its purpose, parameters, and return value

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cd9c2c7168832a92f7fc66dd06eaf9